### PR TITLE
Fixing path error on windows when using the launch option

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -237,7 +237,7 @@ async function main({ mode, uri } = {}) {
 
 	const renpy_file_in_workspace = await vscode.workspace
 		.findFiles('**/game/**/*.rpy', null, 1)
-		.then((files) => (files.length ? files[0].path : null))
+		.then((files) => (files.length ? files[0].fsPath : null))
 
 	const current_file =
 		mode === 'launch'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "renpyWarp",
-	"version": "0.1.1",
+	"version": "0.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"displayName": "Ren'Py warp to line",
 	"packages": {
 		"": {
 			"name": "renpyWarp",
-			"version": "0.1.1",
+			"version": "0.6.0",
 			"dependencies": {
 				"puka": "^1.0.1",
 				"untildify": "^4.0.0",


### PR DESCRIPTION
I hope you don't mind me opening this pull request.

When using this extension on windows, the launch option would not work because the path to the project was wrong.
Regardless of the actual location of the project, an addition C:\ was put at the front of the path.

I fixed this by using fsPath instead of path in the result of findFiles for the project location.